### PR TITLE
Fix gateway invalid sessions; switch to JSON logging

### DIFF
--- a/cmd/ephemeral-roles/ephemeral-roles.go
+++ b/cmd/ephemeral-roles/ephemeral-roles.go
@@ -33,6 +33,16 @@ const (
 	contextTimeout  = 5 * time.Minute
 	monitorInterval = 10 * time.Second
 
+	// identifyStagger staggers each shard's gateway IDENTIFY by shardID *
+	// identifyStagger. Each shard runs as its own StatefulSet pod/process, so
+	// disgo's in-memory IdentifyRateLimiter (which normally spaces IDENTIFY
+	// calls across shards within a single process) has no cross-process view
+	// of the other shards. Without this delay, pods starting around the same
+	// time IDENTIFY within the same window and Discord invalidates the
+	// colliding sessions. 5s matches Discord's default IDENTIFY rate limit
+	// window (see gateway.NewIdentifyRateLimiter's default Wait).
+	identifyStagger = 5 * time.Second
+
 	// intents subscribes to only the gateway events the bot handles: guild,
 	// channel, and role changes (IntentGuilds), the core VoiceStateUpdate
 	// event (IntentGuildVoiceStates), and member changes for the member cache
@@ -156,6 +166,16 @@ func startSession(
 			OperationsGateway:       operations.NewGateway(client),
 		},
 	)
+
+	if delay := time.Duration(envVars.shardID) * identifyStagger; delay > 0 {
+		log.Info("staggering shard startup for gateway IDENTIFY rate limit", "delay", delay)
+
+		select {
+		case <-time.After(delay):
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
 
 	if err := client.OpenShardManager(ctx); err != nil {
 		return nil, err

--- a/cmd/ephemeral-roles/ephemeral-roles.go
+++ b/cmd/ephemeral-roles/ephemeral-roles.go
@@ -170,8 +170,11 @@ func startSession(
 	if delay := time.Duration(envVars.shardID) * identifyStagger; delay > 0 {
 		log.Info("staggering shard startup for gateway IDENTIFY rate limit", "delay", delay)
 
+		timer := time.NewTimer(delay)
+		defer timer.Stop()
+
 		select {
-		case <-time.After(delay):
+		case <-timer.C:
 		case <-ctx.Done():
 			return nil, ctx.Err()
 		}

--- a/deployments/kubernetes/statefulset.yml
+++ b/deployments/kubernetes/statefulset.yml
@@ -20,7 +20,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: ephemeral-roles
-          image: ewohltman/ephemeral-roles:v1.16.1
+          image: ewohltman/ephemeral-roles:v1.16.2
           imagePullPolicy: Always
           env:
             - name: SHARD_COUNT

--- a/internal/pkg/logging/logging.go
+++ b/internal/pkg/logging/logging.go
@@ -132,7 +132,7 @@ func (l *Logger) UpdateLevel(level string) {
 // build (re)constructs the *slog.Logger from the current configuration, fanning
 // out to Discord when a webhook is configured.
 func (l *Logger) build() {
-	var handler slog.Handler = slog.NewTextHandler(l.output, &slog.HandlerOptions{
+	var handler slog.Handler = slog.NewJSONHandler(l.output, &slog.HandlerOptions{
 		Level:       l.level,
 		ReplaceAttr: l.replaceAttr,
 	})

--- a/internal/pkg/logging/logging_test.go
+++ b/internal/pkg/logging/logging_test.go
@@ -130,7 +130,7 @@ func TestLogger_ShardIDAndTimezone(t *testing.T) {
 	log.Info("hello")
 
 	out := buf.String()
-	assert.Contains(t, out, "shardID=7")
+	assert.Contains(t, out, `"shardID":7`)
 	assert.NotContains(t, out, "error parsing timezone location")
 }
 


### PR DESCRIPTION
## Summary
- Each shard runs as its own StatefulSet pod/process, so disgo's in-memory `IdentifyRateLimiter` (meant to space IDENTIFY calls across shards within one process) has no visibility into the other pods. Pods starting close together were IDENTIFYing within Discord's shared 5-second window, which Discord responded to with invalid sessions (`received invalid session`, `failed to reconnect gateway: invalid session`) — matching the pod logs from production. Fix: delay each shard's gateway connect by `shardID * 5s` before opening the shard manager, so IDENTIFYs land in separate windows regardless of pod startup timing.
- Switch stdout logging from `slog.NewTextHandler` to `slog.NewJSONHandler`.
- Bump the StatefulSet image tag to `v1.16.2`.

## Test plan
- [x] `make lint` — 0 issues
- [x] `make test` — 57 tests passing, 80.4% coverage
- [x] `make build`