### PR TITLE
Fix brittle shard startup stagger with a readiness probe

### DIFF
--- a/cmd/ephemeral-roles/ephemeral-roles.go
+++ b/cmd/ephemeral-roles/ephemeral-roles.go
@@ -33,16 +33,6 @@ const (
 	contextTimeout  = 5 * time.Minute
 	monitorInterval = 10 * time.Second
 
-	// identifyStagger staggers each shard's gateway IDENTIFY by shardID *
-	// identifyStagger. Each shard runs as its own StatefulSet pod/process, so
-	// disgo's in-memory IdentifyRateLimiter (which normally spaces IDENTIFY
-	// calls across shards within a single process) has no cross-process view
-	// of the other shards. Without this delay, pods starting around the same
-	// time IDENTIFY within the same window and Discord invalidates the
-	// colliding sessions. 5s matches Discord's default IDENTIFY rate limit
-	// window (see gateway.NewIdentifyRateLimiter's default Wait).
-	identifyStagger = 5 * time.Second
-
 	// intents subscribes to only the gateway events the bot handles: guild,
 	// channel, and role changes (IntentGuilds), the core VoiceStateUpdate
 	// event (IntentGuildVoiceStates), and member changes for the member cache
@@ -166,19 +156,6 @@ func startSession(
 			OperationsGateway:       operations.NewGateway(client),
 		},
 	)
-
-	if delay := time.Duration(envVars.shardID) * identifyStagger; delay > 0 {
-		log.Info("staggering shard startup for gateway IDENTIFY rate limit", "delay", delay)
-
-		timer := time.NewTimer(delay)
-		defer timer.Stop()
-
-		select {
-		case <-timer.C:
-		case <-ctx.Done():
-			return nil, ctx.Err()
-		}
-	}
 
 	if err := client.OpenShardManager(ctx); err != nil {
 		return nil, err

--- a/deployments/kubernetes/statefulset.yml
+++ b/deployments/kubernetes/statefulset.yml
@@ -46,3 +46,11 @@ spec:
           ports:
             - name: http
               containerPort: 8081
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: http
+            initialDelaySeconds: 1
+            periodSeconds: 2
+            timeoutSeconds: 2
+            failureThreshold: 3

--- a/internal/pkg/http/server.go
+++ b/internal/pkg/http/server.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/disgoorg/disgo/bot"
+	"github.com/disgoorg/disgo/gateway"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
@@ -18,6 +19,7 @@ import (
 const (
 	RootEndpoint   = "/"
 	GuildsEndpoint = "/guilds"
+	ReadyzEndpoint = "/readyz"
 )
 
 const (
@@ -47,6 +49,7 @@ func NewServer(log *slog.Logger, client *bot.Client, port string) *http.Server {
 
 	mux.HandleFunc(RootEndpoint, rootHandler())
 	mux.HandleFunc(GuildsEndpoint, guildsHandler(log, client))
+	mux.HandleFunc(ReadyzEndpoint, readyzHandler(client))
 	mux.HandleFunc(pprofIndexEndpoint, pprof.Index)
 	mux.HandleFunc(pprofCmdlineEndpoint, pprof.Cmdline)
 	mux.HandleFunc(pprofProfileEndpoint, pprof.Profile)
@@ -66,6 +69,34 @@ func rootHandler() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		_, _ = io.Copy(io.Discard, r.Body)
 		_ = r.Body.Close()
+		_, _ = w.Write(nil)
+	}
+}
+
+// readyzHandler reports 200 once every shard this process manages has
+// completed its gateway handshake and reached gateway.StatusReady, and 503
+// otherwise. Kubernetes uses this to gate the StatefulSet's OrderedReady
+// rollout: each pod is one shard, and disgo's IdentifyRateLimiter only spaces
+// IDENTIFY calls out within a single process, so without this gate multiple
+// pods starting up in quick succession can IDENTIFY within the same window
+// and have Discord invalidate the colliding sessions.
+func readyzHandler(client *bot.Client) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.Copy(io.Discard, r.Body)
+		_ = r.Body.Close()
+
+		if !client.HasShardManager() {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+
+		for shard := range client.ShardManager.Shards() {
+			if shard.Status() != gateway.StatusReady {
+				w.WriteHeader(http.StatusServiceUnavailable)
+				return
+			}
+		}
+
 		_, _ = w.Write(nil)
 	}
 }

--- a/internal/pkg/http/server_test.go
+++ b/internal/pkg/http/server_test.go
@@ -49,6 +49,7 @@ func TestNewServer(t *testing.T) {
 
 	testRootEndpoint(t, client)
 	testGuildsEndpoint(t, client)
+	testReadyzEndpoint(t, client)
 
 	ctx, cancelContext := context.WithTimeout(t.Context(), time.Second)
 	defer cancelContext()
@@ -63,6 +64,20 @@ func testRootEndpoint(t *testing.T, client *http.Client) {
 	require.NoError(t, err)
 
 	drainCloseResponse(resp)
+}
+
+func testReadyzEndpoint(t *testing.T, client *http.Client) {
+	t.Helper()
+
+	// mock.NewSession does not configure a shard manager, so readyz reports
+	// not ready, matching a real process before its gateway connection
+	// reaches gateway.StatusReady.
+	resp, err := doRequest(t.Context(), client, testURL+internalHTTP.ReadyzEndpoint)
+	require.NoError(t, err)
+
+	drainCloseResponse(resp)
+
+	assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
 }
 
 func testGuildsEndpoint(t *testing.T, client *http.Client) {


### PR DESCRIPTION
## Summary
The previous fix (#442) staggered each shard's gateway IDENTIFY by a fixed `shardID * 5s` delay computed from the pod's own process start time. Live logs from the `ephemeral-roles` namespace (`kubectl logs`) showed this was brittle: only the first few shards connected cleanly, and several higher-numbered shards still logged `received invalid session` / `failed to reconnect gateway: invalid session`.

Root cause of the brittleness: the StatefulSet has no readiness probe, so pods become "Ready" (and the next ordinal starts) as soon as the container is Running — only ~1-3s apart in practice, not the assumed 5s. Combined with variable connect/TLS/Hello latency, different shards' actual IDENTIFY attempts kept landing in the same Discord rate-limit window and colliding.

- Removed the fixed-delay stagger.
- Added a `/readyz` HTTP endpoint (`internal/pkg/http/server.go`) that reports ready only once the process's shard reaches `gateway.StatusReady`.
- Wired `/readyz` up as the StatefulSet's `readinessProbe`. With the default `OrderedReady` pod management policy, Kubernetes now holds off creating each next shard's pod until the previous shard has actually finished its gateway handshake — no fixed-time guessing.

## Test plan
- [x] `make lint` — 0 issues
- [x] `make test` — 57 tests passing
- [x] `make build`
- [ ] Verify in the live cluster after deploy: `kubectl logs -n ephemeral-roles <pod>` shows no more `invalid session` warnings across all 10 shards, and `kubectl get pods -n ephemeral-roles` shows pods becoming Ready sequentially with real spacing.