### PR TITLE
Update StatefulSet image to v1.16.3

### DIFF
--- a/deployments/kubernetes/statefulset.yml
+++ b/deployments/kubernetes/statefulset.yml
@@ -20,7 +20,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: ephemeral-roles
-          image: ewohltman/ephemeral-roles:v1.16.2
+          image: ewohltman/ephemeral-roles:v1.16.3
           imagePullPolicy: Always
           env:
             - name: SHARD_COUNT


### PR DESCRIPTION
## Summary
- Bump the ephemeral-roles StatefulSet image tag to v1.16.3, which includes the /readyz-gated shard startup fix from #444.

## Test plan
- [ ] CI passes (Build, DeepSource, claude-review)