### PR TITLE
Fix shard wedge: bound REST rate-limit waits, drop events on full guild queue

### DIFF
--- a/deployments/kubernetes/statefulset.yml
+++ b/deployments/kubernetes/statefulset.yml
@@ -20,7 +20,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: ephemeral-roles
-          image: ewohltman/ephemeral-roles:v1.16.4
+          image: ewohltman/ephemeral-roles:v1.16.5
           imagePullPolicy: Always
           env:
             - name: SHARD_COUNT

--- a/deployments/kubernetes/statefulset.yml
+++ b/deployments/kubernetes/statefulset.yml
@@ -17,7 +17,7 @@ spec:
       labels:
         app: ephemeral-roles
     spec:
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 90
       containers:
         - name: ephemeral-roles
           image: ewohltman/ephemeral-roles:v1.16.5

--- a/internal/pkg/callbacks/channelDelete.go
+++ b/internal/pkg/callbacks/channelDelete.go
@@ -3,7 +3,10 @@ package callbacks
 import (
 	"github.com/disgoorg/disgo/discord"
 	"github.com/disgoorg/disgo/events"
+	"github.com/disgoorg/disgo/rest"
 	"github.com/disgoorg/snowflake/v2"
+
+	"github.com/ewohltman/ephemeral-roles/internal/pkg/operations"
 )
 
 const channelDeleteEventError = unableToProcessEvent + "ChannelDelete"
@@ -18,9 +21,14 @@ func (handler *Handler) ChannelDelete(event *events.GuildChannelDelete) {
 		return
 	}
 
-	handler.sequencer.Submit(event.GuildID, func() {
+	accepted := handler.sequencer.Submit(event.GuildID, func() {
 		handler.handleChannelDelete(event)
 	})
+	if !accepted {
+		handler.Log.Warn("dropping ChannelDelete event: guild queue full",
+			"guildID", event.GuildID,
+		)
+	}
 }
 
 func (handler *Handler) handleChannelDelete(event *events.GuildChannelDelete) {
@@ -48,7 +56,10 @@ func (handler *Handler) handleChannelDelete(event *events.GuildChannelDelete) {
 		return
 	}
 
-	if err := client.Rest.DeleteRole(event.GuildID, roleID); err != nil {
+	ctx, cancel := operations.RequestContext()
+	defer cancel()
+
+	if err := client.Rest.DeleteRole(event.GuildID, roleID, rest.WithCtx(ctx)); err != nil {
 		handler.Log.Error(channelDeleteEventError, "error", err)
 		return
 	}

--- a/internal/pkg/callbacks/channelDelete.go
+++ b/internal/pkg/callbacks/channelDelete.go
@@ -25,9 +25,18 @@ func (handler *Handler) ChannelDelete(event *events.GuildChannelDelete) {
 		handler.handleChannelDelete(event)
 	})
 	if !accepted {
-		handler.Log.Warn("dropping ChannelDelete event: guild queue full",
+		// Unlike a dropped VoiceStateUpdate, a dropped ChannelDelete is never
+		// retried by a later event, permanently leaking a role toward the
+		// guild's 250-role cap. ChannelDelete is rare, so fall back to a
+		// goroutine that waits for queue capacity: the read loop stays
+		// unblocked and the work still runs serialized on the guild worker.
+		handler.Log.Warn("guild queue full: queueing ChannelDelete asynchronously",
 			"guildID", event.GuildID,
 		)
+
+		go handler.sequencer.SubmitWait(event.GuildID, func() {
+			handler.handleChannelDelete(event)
+		})
 	}
 }
 

--- a/internal/pkg/callbacks/sequencer.go
+++ b/internal/pkg/callbacks/sequencer.go
@@ -7,8 +7,8 @@ import (
 )
 
 // guildQueueBuffer bounds how many pending guild-scoped jobs may queue up
-// behind a slow one before Submit blocks. Sized well above realistic
-// per-guild event bursts (channel switches are human-paced).
+// behind a slow one. Sized well above realistic per-guild event bursts
+// (channel switches are human-paced).
 const guildQueueBuffer = 64
 
 // guildSequencer serializes Discord role-mutating work per guild, so that
@@ -29,8 +29,42 @@ type guildSequencer struct {
 // Submit queues fn to run on guildID's dedicated worker, creating the worker
 // on first use. fn runs after any previously submitted work for the same
 // guild has completed.
-func (s *guildSequencer) Submit(guildID snowflake.ID, fn func()) {
+//
+// Submit never blocks: if the guild's queue is full, fn is dropped and Submit
+// reports false. The caller holds disgo's event-manager mutex, so blocking
+// here would wedge all event dispatch for the shard — including heartbeat
+// ACK processing — until the queue drains (a production incident: a Discord
+// role-create rate limit with a multi-hour retry_after backed up a guild
+// queue and put the shard into a permanent zombie-reconnect loop). Dropping
+// risks at most a stale ephemeral role, which the member's next voice event
+// corrects.
+func (s *guildSequencer) Submit(guildID snowflake.ID, fn func()) bool {
+	select {
+	case s.queue(guildID) <- fn:
+		return true
+	default:
+		return false
+	}
+}
+
+// Flush blocks until every job submitted for guildID before this call has
+// completed. Unlike Submit, Flush waits for queue capacity rather than
+// dropping; it is intended for tests and shutdown paths, not the gateway
+// read loop.
+func (s *guildSequencer) Flush(guildID snowflake.ID) {
+	done := make(chan struct{})
+
+	s.queue(guildID) <- func() { close(done) }
+
+	<-done
+}
+
+// queue returns guildID's job channel, creating it and starting its drain
+// worker on first use.
+func (s *guildSequencer) queue(guildID snowflake.ID) chan func() {
 	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	if s.queues == nil {
 		s.queues = make(map[snowflake.ID]chan func())
 	}
@@ -42,19 +76,8 @@ func (s *guildSequencer) Submit(guildID snowflake.ID, fn func()) {
 
 		go drainGuildQueue(queue)
 	}
-	s.mu.Unlock()
 
-	queue <- fn
-}
-
-// Flush blocks until every job submitted for guildID before this call has
-// completed.
-func (s *guildSequencer) Flush(guildID snowflake.ID) {
-	done := make(chan struct{})
-
-	s.Submit(guildID, func() { close(done) })
-
-	<-done
+	return queue
 }
 
 func drainGuildQueue(queue chan func()) {

--- a/internal/pkg/callbacks/sequencer.go
+++ b/internal/pkg/callbacks/sequencer.go
@@ -47,14 +47,21 @@ func (s *guildSequencer) Submit(guildID snowflake.ID, fn func()) bool {
 	}
 }
 
+// SubmitWait queues fn like Submit but blocks until the guild's queue has
+// capacity instead of dropping. It must not be called from the gateway read
+// loop; it is for callers that can afford to wait (a goroutine falling back
+// after a Submit drop, tests) while still needing fn to run serialized on
+// the guild's worker.
+func (s *guildSequencer) SubmitWait(guildID snowflake.ID, fn func()) {
+	s.queue(guildID) <- fn
+}
+
 // Flush blocks until every job submitted for guildID before this call has
-// completed. Unlike Submit, Flush waits for queue capacity rather than
-// dropping; it is intended for tests and shutdown paths, not the gateway
-// read loop.
+// completed.
 func (s *guildSequencer) Flush(guildID snowflake.ID) {
 	done := make(chan struct{})
 
-	s.queue(guildID) <- func() { close(done) }
+	s.SubmitWait(guildID, func() { close(done) })
 
 	<-done
 }

--- a/internal/pkg/callbacks/voiceStateUpdate.go
+++ b/internal/pkg/callbacks/voiceStateUpdate.go
@@ -38,9 +38,14 @@ type voiceStateUpdateMetadata struct {
 func (handler *Handler) VoiceStateUpdate(event *events.GuildVoiceStateUpdate) {
 	handler.VoiceStateUpdateCounter.Inc()
 
-	handler.sequencer.Submit(event.VoiceState.GuildID, func() {
+	accepted := handler.sequencer.Submit(event.VoiceState.GuildID, func() {
 		handler.handleVoiceStateUpdate(event)
 	})
+	if !accepted {
+		handler.Log.Warn("dropping VoiceStateUpdate event: guild queue full",
+			"guildID", event.VoiceState.GuildID,
+		)
+	}
 }
 
 func (handler *Handler) handleVoiceStateUpdate(event *events.GuildVoiceStateUpdate) {

--- a/internal/pkg/operations/operations.go
+++ b/internal/pkg/operations/operations.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/disgoorg/disgo/bot"
 	"github.com/disgoorg/disgo/discord"
@@ -22,7 +23,23 @@ const APIErrorCodeMaxRoles = rest.JSONErrorCodeMaximumGuildRolesReached
 const (
 	roleHoist   = true
 	roleMention = true
+
+	// requestTimeout bounds each Discord REST request, including the time
+	// spent queued in disgo's REST rate limiter. Discord can respond to role
+	// mutations with retry_after values of an hour or more; without a
+	// deadline the rate limiter blocks the calling goroutine for that entire
+	// window (observed wedging a shard's guild worker for 96+ minutes in
+	// production). Failing fast with context.DeadlineExceeded instead lets
+	// callers classify the error (KindDeadlineExceeded) and drop the
+	// operation.
+	requestTimeout = 1 * time.Minute
 )
+
+// RequestContext returns a context bounding a single Discord REST request,
+// and its cancel function.
+func RequestContext() (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.Background(), requestTimeout)
+}
 
 // Gateway is a centralized construct to process Discord API-mutating requests
 // by de-duplicating identical simultaneous requests and providing the result
@@ -65,7 +82,10 @@ func LookupGuild(client *bot.Client, guildID snowflake.ID) (discord.Guild, error
 		return guild, nil
 	}
 
-	restGuild, err := client.Rest.GetGuild(guildID, false)
+	ctx, cancel := RequestContext()
+	defer cancel()
+
+	restGuild, err := client.Rest.GetGuild(guildID, false, rest.WithCtx(ctx))
 	if err != nil {
 		return discord.Guild{}, fmt.Errorf("unable to query guild: %w", err)
 	}
@@ -79,7 +99,10 @@ func LookupGuild(client *bot.Client, guildID snowflake.ID) (discord.Guild, error
 // user associated with the provided userID, in the guild associated with the
 // provided guildID.
 func AddRoleToMember(client *bot.Client, guildID, userID, roleID snowflake.ID) error {
-	if err := client.Rest.AddMemberRole(guildID, userID, roleID); err != nil {
+	ctx, cancel := RequestContext()
+	defer cancel()
+
+	if err := client.Rest.AddMemberRole(guildID, userID, roleID, rest.WithCtx(ctx)); err != nil {
 		return fmt.Errorf("unable to add ephemeral role: %w", err)
 	}
 
@@ -90,7 +113,10 @@ func AddRoleToMember(client *bot.Client, guildID, userID, roleID snowflake.ID) e
 // from the user associated with the provided userID, in the guild associated
 // with the provided guildID.
 func RemoveRoleFromMember(client *bot.Client, guildID, userID, roleID snowflake.ID) error {
-	if err := client.Rest.RemoveMemberRole(guildID, userID, roleID); err != nil {
+	ctx, cancel := RequestContext()
+	defer cancel()
+
+	if err := client.Rest.RemoveMemberRole(guildID, userID, roleID, rest.WithCtx(ctx)); err != nil {
 		return fmt.Errorf("unable to remove ephemeral role: %w", err)
 	}
 
@@ -161,12 +187,15 @@ func createRole(
 	roleName string,
 	roleColor int,
 ) (discord.Role, error) {
+	ctx, cancel := RequestContext()
+	defer cancel()
+
 	role, err := client.Rest.CreateRole(guildID, discord.RoleCreate{
 		Name:        roleName,
 		Color:       roleColor,
 		Hoist:       roleHoist,
 		Mentionable: roleMention,
-	})
+	}, rest.WithCtx(ctx))
 	if err != nil {
 		return discord.Role{}, fmt.Errorf("unable to create ephemeral role: %w", err)
 	}


### PR DESCRIPTION
## Summary
Shard 3 re-entered the zombie/invalid-session reconnect loop on v1.16.4 (~2h after rollout; same pattern as v1.16.2/v1.16.3: clean for hours, then permanently wedged until pod restart). This time the pod was diagnosed live via its pprof endpoint (`/debug/pprof/goroutine?debug=2`), which produced a definitive failure chain:

1. The affected guild's sequencer worker was blocked **96+ minutes** inside `CreateRole`, waiting in disgo's REST rate limiter. Discord can return `retry_after` values of an hour or more for role mutations, and none of our REST calls carried a deadline, so the rate limiter blocked for the entire window.
2. Voice events kept arriving for that guild until its 64-slot queue filled; `sequencer.Submit` then blocked the gateway read loop on the channel send — while holding disgo's event-manager mutex (`eventManagerImpl.mu`, held for the duration of `HandleGatewayEvent`).
3. Every reconnect's fresh read loop blocked on that same mutex at its first dispatch, so heartbeat ACKs were never read: zombie close → reconnect → wedge again, indefinitely (the exact 82.5s = 2× heartbeat-interval periodicity seen in the logs).

The same unbounded rate-limiter wait also explains the pre-sequencer incidents on v1.16.2/v1.16.3, where the wait ran directly on the read loop.

## Changes
- **Bound all Discord REST calls** (`CreateRole`, `AddMemberRole`, `RemoveMemberRole`, `GetGuild`, `DeleteRole`) with a 1-minute context via `rest.WithCtx`, which disgo's REST rate limiter honors. Oversized `retry_after` windows now fail fast as `context.DeadlineExceeded`, which callers already classify (`KindDeadlineExceeded`) and log at debug.
- **`sequencer.Submit` never blocks**: if a guild's queue is full the event is dropped (reported to the caller, logged at warn). A dropped event risks at most a stale ephemeral role — corrected by the member's next voice event — while blocking wedged the entire shard's event dispatch.
- Bump StatefulSet image tag to v1.16.5.

## Test plan
- [x] `make lint` — 0 issues
- [x] `make test` — 57 tests passing (with `-race`)
- [x] `make build`
- [ ] Post-deploy: watch `kubectl logs -n ephemeral-roles` across all shards; shard 3 should either stay clean or log `dropping VoiceStateUpdate event: guild queue full` / debug-level deadline-exceeded instead of wedging.